### PR TITLE
Auto tune is disabled so u64:MAX should be used as time

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -21,7 +21,7 @@ pub fn interval_mod_setup(
     donation_conf: &DonationConfig,
 ) -> (u64, Option<u64>) {
     if donation_conf.percentage >= DONATION_THRESHOLD && !worker_conf.auto_tune {
-        return (100 * 60, Some(1));
+        return (std::u64::MAX, Some(1));
     }
 
     let interval = if worker_conf.auto_tune {

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -62,7 +62,7 @@ fn test_interval_mod_setup_donation_enabled_auto_tune_disabled() {
     let donation_conf = DonationConfig { percentage: 2.5 };
 
     let (interval, donation_mod) = timer::interval_mod_setup(&worker_conf, &donation_conf);
-    assert_eq!(interval, 100 * 60);
+    assert_eq!(interval, std::u64::MAX);
     assert_eq!(donation_mod, Some(1));
 }
 


### PR DESCRIPTION
In the if statement in timer.rs line 27 if auto tune is disabled youre falling back to the max.. So I assume you want to do the same here