### PR TITLE
fix: Build fails on current nightly version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/benches/hash.rs
+++ b/benches/hash.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![feature(box_syntax)]
 
 extern crate mithril;
 extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![crate_name = "mithril"]
 #![crate_type = "lib"]
-#![feature(repr_simd)]
-#![feature(integer_atomics)]
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Looks like there were some nightly features that didn't get stabilized (or that did get stabilized and were thus obsolete). This PR removes the macros that set those features.

This PR also adds the `workflow_dispatch` trigger to CI, which lets you re-trigger a flaky test, for example. Super tiny addition.